### PR TITLE
Create a `use-hits` hook and call then on page create

### DIFF
--- a/functions/api/get-article-hits.ts
+++ b/functions/api/get-article-hits.ts
@@ -23,5 +23,8 @@ export const onRequest: PagesFunction<Env> = async context => {
     }
     const newValue = (parseInt(value) + 1).toString();
     await context.env.KV.put(slug, newValue);
-    return new Response(newValue, {status: 200});
+    return new Response(JSON.stringify({hits: newValue}), {
+        status: 200,
+        headers: {"Content-Type": "application/json; charset=utf-8"}
+    });
 };

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -1,43 +1,48 @@
-import path from "path"
+import path from "path";
+import type {GatsbyNode} from "gatsby";
 
-
-exports.createPages = async ({ graphql, actions, reporter }) => {
-  const { createPage } = actions
-  const postTemplate = path.resolve(`./src/templates/post.tsx`)
-  const result = await graphql(`
-    query {
-      allMdx {
-        nodes {
-          id
-          frontmatter {
-            slug
-          }
-          internal {
-            contentFilePath
-          }
+export const createPages: GatsbyNode["createPages"] = async ({
+    graphql,
+    actions,
+    reporter
+}) => {
+    const {createPage} = actions;
+    const postTemplate = path.resolve(`./src/templates/post.tsx`);
+    const result = await graphql(`
+        query {
+            allMdx {
+                nodes {
+                    id
+                    frontmatter {
+                        slug
+                    }
+                    internal {
+                        contentFilePath
+                    }
+                }
+            }
         }
-      }
+    `);
+
+    if (result.errors) {
+        reporter.panicOnBuild("Error loading MDX result", result.errors);
     }
-  `)
 
-  if (result.errors) {
-    reporter.panicOnBuild('Error loading MDX result', result.errors)
-  }
+    // Create blog post pages.
+    const posts = (result.data as Queries.Query).allMdx.nodes as Queries.Mdx[] &
+        Queries.MdxFrontmatter;
 
-  // Create blog post pages.
-  const posts = result.data.allMdx.nodes
-
-  // you'll call `createPage` for each result
-  posts.forEach(node => {
-    createPage({
-      // As mentioned above you could also query something else like frontmatter.title above and use a helper function
-      // like slugify to create a slug
-      path: node.frontmatter.slug,
-      // Provide the path to the MDX content file so webpack can pick it up and transform it into JSX
-      component: `${postTemplate}?__contentFilePath=${node.internal.contentFilePath}`,
-      // You can use the values in this context in
-      // our page layout component
-      context: { id: node.id },
-    })
-  })
-}
+    // you'll call `createPage` for each result
+    posts.forEach(node => {
+        createPage({
+            // As mentioned above you could also query something else like frontmatter.title above and use a helper function
+            // like slugify to create a slug
+            path: node.frontmatter?.slug as string,
+            // Provide the path to the MDX content file so webpack can pick it up and transform it into JSX
+            component: `${postTemplate}?__contentFilePath=${node.internal.contentFilePath}`,
+            // You can use the values in this context in
+            // our page layout component
+            context: {id: node.id}
+        });
+    });
+};

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {useSiteMetadata} from "../hooks/use-site-metadata";
-import {joinTwoUrls} from "../utils/join-two-urls";
+import joinTwoUrls from "../utils/join-two-urls";
 
 export const SEO = ({
     title,

--- a/src/hooks/use-hits.tsx
+++ b/src/hooks/use-hits.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import generateKeyFromSlug from "../utils/generate-key-from-slug";
+
+export default function useHits(slug: string) {
+    const [hits, setHits] = React.useState<number | null>(null);
+
+    React.useEffect(() => {
+        const key = generateKeyFromSlug(slug);
+        // Register the article as seen!
+        if (process.env.NODE_ENV === "production") {
+            // Fetch the # of hits, this should increment the hits too
+            fetch(`/api/get-article-hits?slug=${key}`)
+                .then(res => res.json())
+                .then(json => {
+                    if (typeof json.hits === "string") {
+                        setHits(parseInt(json.hits) + 1);
+                    }
+                }).catch((reason) => {
+                    console.error(reason);
+                });
+        } else {
+            setHits(1337);
+        }
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return hits;
+}

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import {MDXProvider} from "@mdx-js/react";
 import {Link, HeadFC, graphql} from "gatsby";
 import {SEO} from "../components/seo";
+import useHits from "../hooks/use-hits";
+
 import * as styles from "../styles/post.module.scss";
 
 const shortcodes = {Link}; // Provide common components here
@@ -13,6 +15,7 @@ export default function PageTemplate({
     data: Queries.PageTemplateQuery;
     children: React.ReactNode;
 }) {
+    useHits(data.mdx?.frontmatter?.slug as string);
     return (
         <div className={styles.container}>
             <h1 className={styles.postTitle}>{data.mdx?.frontmatter?.title}</h1>

--- a/src/utils/generate-key-from-slug.ts
+++ b/src/utils/generate-key-from-slug.ts
@@ -1,0 +1,13 @@
+const generateKeyFromSlug = (slug: string) => {
+    // remove first slash
+    if (slug.startsWith('/')) {
+        slug = slug.slice(1);
+    }
+    // remove last slash
+    if (slug.endsWith('/')) {
+        slug = slug.slice(0, -1);
+    }
+    return slug.replace(/[^a-z0-9]/gi, '-').toLowerCase();
+}
+
+export default generateKeyFromSlug;

--- a/src/utils/join-two-urls.ts
+++ b/src/utils/join-two-urls.ts
@@ -8,4 +8,4 @@ const joinTwoUrls = (url1: string, url2: string | undefined) => {
     return new URL(url2, url1).toString();
 };
 
-export {joinTwoUrls};
+export default joinTwoUrls;


### PR DESCRIPTION
- This should send a request to the function on hit
- Helps in finding the popular page

Also:
- Make `joinTwoUrls` a default function
- functions: return json value instead of plain text
- Fix some type errors in gatsby-node.ts 